### PR TITLE
Add RPi 5 shutdown-diagnostics logging scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 test-volume
+scripts/.rpi-mac
 .DS_Store
 /volumes
 node_modules

--- a/scripts/rpi-monitor-install.sh
+++ b/scripts/rpi-monitor-install.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Installs the rpi-monitor and rpi-shutdown-capture services on a Raspberry Pi.
+#
+# Usage:  ./rpi-monitor-install.sh <pi-host> [ssh-user]
+#         ./rpi-monitor-install.sh raspberrypi.local
+#         ./rpi-monitor-install.sh 192.168.1.42 pi
+#
+# Requires: ssh access with sudo on the target host.
+
+set -euo pipefail
+
+PI_HOST="${1:?Usage: $0 <pi-host> [ssh-user]}"
+SSH_USER="${2:-$(whoami)}"
+SSH="${SSH_USER}@${PI_HOST}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+info()  { echo "[install] $*"; }
+fatal() { echo "[ERROR]   $*" >&2; exit 1; }
+
+command -v ssh  >/dev/null || fatal "ssh not found"
+command -v scp  >/dev/null || fatal "scp not found"
+
+info "Copying scripts to ${SSH}:/tmp/ ..."
+scp "${SCRIPT_DIR}/rpi-monitor.sh" \
+    "${SCRIPT_DIR}/rpi-shutdown-capture.sh" \
+    "${SSH}:/tmp/"
+
+info "Installing binaries and systemd units ..."
+# shellcheck disable=SC2087
+ssh -tt "$SSH" bash <<'REMOTE'
+set -euo pipefail
+
+sudo install -m 755 /tmp/rpi-monitor.sh          /usr/local/bin/rpi-monitor.sh
+sudo install -m 755 /tmp/rpi-shutdown-capture.sh  /usr/local/bin/rpi-shutdown-capture.sh
+
+sudo mkdir -p /var/log/rpi-monitor
+
+# Write the monitor service
+sudo tee /etc/systemd/system/rpi-monitor.service > /dev/null <<'EOF'
+[Unit]
+Description=Raspberry Pi system health monitor
+After=multi-user.target
+Wants=multi-user.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/rpi-monitor.sh 30
+Restart=always
+RestartSec=5
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=rpi-monitor
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+# Write the shutdown-capture service
+sudo tee /etc/systemd/system/rpi-shutdown-capture.service > /dev/null <<'EOF'
+[Unit]
+Description=Capture Raspberry Pi system state immediately before shutdown
+DefaultDependencies=no
+Before=shutdown.target reboot.target halt.target
+Requires=local-fs.target
+After=local-fs.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStop=/usr/local/bin/rpi-shutdown-capture.sh
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now rpi-monitor.service
+sudo systemctl enable rpi-shutdown-capture.service
+
+echo "Status of rpi-monitor:"
+sudo systemctl status rpi-monitor.service --no-pager || true
+REMOTE
+
+info "Done. Logs will appear in /var/log/rpi-monitor/ on the Pi."
+info "To tail the live log:  ssh ${SSH} 'tail -f /var/log/rpi-monitor/rpi-monitor-\$(date +%Y-%m-%d).log'"
+info "Shutdown snapshots are saved as /var/log/rpi-monitor/shutdown-<timestamp>.log"

--- a/scripts/rpi-monitor-install.sh
+++ b/scripts/rpi-monitor-install.sh
@@ -1,17 +1,21 @@
 #!/usr/bin/env bash
 # Installs the rpi-monitor and rpi-shutdown-capture services on a Raspberry Pi.
+# Optionally configures Wake-on-LAN so the Pi can be woken remotely after a
+# clean OS shutdown (use --wol to enable).
 #
-# Usage:  ./rpi-monitor-install.sh <pi-host> [ssh-user]
+# Usage:  ./rpi-monitor-install.sh <pi-host> [ssh-user] [--wol]
 #         ./rpi-monitor-install.sh raspberrypi.local
-#         ./rpi-monitor-install.sh 192.168.1.42 pi
+#         ./rpi-monitor-install.sh 192.168.1.42 pi --wol
 #
 # Requires: ssh access with sudo on the target host.
 
 set -euo pipefail
 
-PI_HOST="${1:?Usage: $0 <pi-host> [ssh-user]}"
+PI_HOST="${1:?Usage: $0 <pi-host> [ssh-user] [--wol]}"
 SSH_USER="${2:-$(whoami)}"
 SSH="${SSH_USER}@${PI_HOST}"
+SETUP_WOL=false
+for arg in "$@"; do [[ "$arg" == "--wol" ]] && SETUP_WOL=true; done
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
@@ -22,9 +26,12 @@ command -v ssh  >/dev/null || fatal "ssh not found"
 command -v scp  >/dev/null || fatal "scp not found"
 
 info "Copying scripts to ${SSH}:/tmp/ ..."
-scp "${SCRIPT_DIR}/rpi-monitor.sh" \
-    "${SCRIPT_DIR}/rpi-shutdown-capture.sh" \
-    "${SSH}:/tmp/"
+SCRIPTS_TO_COPY=(
+  "${SCRIPT_DIR}/rpi-monitor.sh"
+  "${SCRIPT_DIR}/rpi-shutdown-capture.sh"
+)
+"$SETUP_WOL" && SCRIPTS_TO_COPY+=("${SCRIPT_DIR}/rpi-wol-setup.sh")
+scp "${SCRIPTS_TO_COPY[@]}" "${SSH}:/tmp/"
 
 info "Installing binaries and systemd units ..."
 # shellcheck disable=SC2087
@@ -81,6 +88,18 @@ sudo systemctl enable rpi-shutdown-capture.service
 echo "Status of rpi-monitor:"
 sudo systemctl status rpi-monitor.service --no-pager || true
 REMOTE
+
+if "$SETUP_WOL"; then
+  info "Configuring Wake-on-LAN..."
+  MAC=$(ssh "$SSH" "sudo bash /tmp/rpi-wol-setup.sh" \
+    | tee /dev/stderr \
+    | grep "MAC address:" | awk '{print $NF}')
+  if [[ -n "$MAC" ]]; then
+    echo "$MAC" > "${SCRIPT_DIR}/.rpi-mac"
+    info "MAC address saved to scripts/.rpi-mac"
+    info "To wake the Pi: ./scripts/rpi-wake.sh"
+  fi
+fi
 
 info "Done. Logs will appear in /var/log/rpi-monitor/ on the Pi."
 info "To tail the live log:  ssh ${SSH} 'tail -f /var/log/rpi-monitor/rpi-monitor-\$(date +%Y-%m-%d).log'"

--- a/scripts/rpi-monitor.service
+++ b/scripts/rpi-monitor.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Raspberry Pi system health monitor
+Documentation=https://github.com/marktheknife/docker-homebridge
+After=multi-user.target
+Wants=multi-user.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/rpi-monitor.sh 30
+Restart=always
+RestartSec=5
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=rpi-monitor
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/rpi-monitor.sh
+++ b/scripts/rpi-monitor.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# Periodic system-health logger for Raspberry Pi 5.
+# Designed to help diagnose unexpected shutdowns by logging temperature,
+# throttle flags, voltage, CPU frequency, memory, and kernel warnings.
+#
+# Usage: rpi-monitor.sh [interval_seconds]  (default: 30)
+#
+# Logs rotate daily; LOG_KEEP_DAYS controls retention.
+
+set -euo pipefail
+
+INTERVAL="${1:-30}"
+LOG_DIR="/var/log/rpi-monitor"
+LOG_KEEP_DAYS=14
+
+mkdir -p "$LOG_DIR"
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+log_file() {
+  echo "${LOG_DIR}/rpi-monitor-$(date +%Y-%m-%d).log"
+}
+
+rotate_logs() {
+  find "$LOG_DIR" -name "rpi-monitor-*.log" -mtime +"$LOG_KEEP_DAYS" -delete 2>/dev/null || true
+}
+
+# Decode the vcgencmd get_throttled bitmask into human-readable flags.
+decode_throttle() {
+  local raw="$1"
+  local val
+  val=$(( raw ))   # handles "throttled=0x50005" if passed as hex string
+
+  local flags=()
+  (( val & 0x1     )) && flags+=("UNDER_VOLTAGE_NOW")
+  (( val & 0x2     )) && flags+=("ARM_FREQ_CAPPED_NOW")
+  (( val & 0x4     )) && flags+=("THROTTLED_NOW")
+  (( val & 0x8     )) && flags+=("SOFT_TEMP_LIMIT_NOW")
+  (( val & 0x10000 )) && flags+=("under_voltage_occurred")
+  (( val & 0x20000 )) && flags+=("arm_freq_capped_occurred")
+  (( val & 0x40000 )) && flags+=("throttling_occurred")
+  (( val & 0x80000 )) && flags+=("soft_temp_limit_occurred")
+
+  if [[ ${#flags[@]} -eq 0 ]]; then
+    echo "OK"
+  else
+    local IFS="|"
+    echo "${flags[*]}"
+  fi
+}
+
+vcgencmd_safe() {
+  vcgencmd "$@" 2>/dev/null || echo "unavailable"
+}
+
+# ── Single sample ─────────────────────────────────────────────────────────────
+
+collect() {
+  local ts
+  ts="$(date '+%Y-%m-%dT%H:%M:%S')"
+  local out
+  out="$(log_file)"
+
+  {
+    echo "──────────────────────────────────────────── ${ts}"
+
+    # Uptime / load
+    echo "  uptime     : $(uptime -p 2>/dev/null || uptime)"
+    echo "  load_avg   : $(cut -d' ' -f1-3 /proc/loadavg)"
+
+    # Memory
+    local mem_total mem_avail mem_used_pct
+    mem_total=$(awk '/^MemTotal/  {print $2}' /proc/meminfo)
+    mem_avail=$(awk '/^MemAvailable/ {print $2}' /proc/meminfo)
+    mem_used_pct=$(( (mem_total - mem_avail) * 100 / mem_total ))
+    printf "  memory     : %d MiB total, %d MiB avail (%d%% used)\n" \
+      "$(( mem_total / 1024 ))" "$(( mem_avail / 1024 ))" "$mem_used_pct"
+
+    # CPU frequencies (all cores)
+    local freqs=()
+    for f in /sys/devices/system/cpu/cpu*/cpufreq/scaling_cur_freq; do
+      [[ -r "$f" ]] && freqs+=("$(( $(cat "$f") / 1000 ))MHz")
+    done
+    if [[ ${#freqs[@]} -gt 0 ]]; then
+      echo "  cpu_freq   : ${freqs[*]}"
+    fi
+
+    # Thermal zones
+    for zone_dir in /sys/class/thermal/thermal_zone*; do
+      [[ -r "${zone_dir}/temp" ]] || continue
+      local type temp_raw temp_c
+      type=$(cat "${zone_dir}/type" 2>/dev/null || basename "$zone_dir")
+      temp_raw=$(cat "${zone_dir}/temp")
+      temp_c=$(awk "BEGIN {printf \"%.1f\", ${temp_raw}/1000}")
+      printf "  %-10s : %s°C\n" "$type" "$temp_c"
+    done
+
+    # vcgencmd: temp, throttle, voltages
+    local raw_temp
+    raw_temp=$(vcgencmd_safe measure_temp)
+    echo "  vcgencmd_t : ${raw_temp}"
+
+    local raw_throttle throttle_hex throttle_flags
+    raw_throttle=$(vcgencmd_safe get_throttled)
+    # raw_throttle looks like "throttled=0x50005"
+    throttle_hex="${raw_throttle#*=}"
+    if [[ "$throttle_hex" == "unavailable" ]]; then
+      throttle_flags="unavailable"
+    else
+      throttle_flags=$(decode_throttle "$throttle_hex")
+    fi
+    echo "  throttled  : ${raw_throttle}  →  ${throttle_flags}"
+
+    for rail in core sdram_c sdram_i sdram_p; do
+      local v
+      v=$(vcgencmd_safe measure_volts "$rail")
+      printf "  volts_%-8s: %s\n" "$rail" "$v"
+    done
+
+    # Recent kernel messages that mention thermal, power, or voltage issues
+    local dmesg_hits
+    dmesg_hits=$(dmesg --time-format iso 2>/dev/null \
+      | grep -iE "(thermal|throttl|over.temp|under.volt|voltage|power|reboot|panic|oom|killed)" \
+      | tail -5 \
+      || true)
+    if [[ -n "$dmesg_hits" ]]; then
+      echo "  dmesg_warn :"
+      while IFS= read -r line; do
+        echo "    $line"
+      done <<< "$dmesg_hits"
+    else
+      echo "  dmesg_warn : (none)"
+    fi
+
+  } >> "$out"
+}
+
+# ── Main loop ─────────────────────────────────────────────────────────────────
+
+echo "rpi-monitor started (interval=${INTERVAL}s, log_dir=${LOG_DIR})" \
+  >> "$(log_file)"
+
+rotate_logs
+
+while true; do
+  collect
+  rotate_logs
+  sleep "$INTERVAL"
+done

--- a/scripts/rpi-shutdown-capture.service
+++ b/scripts/rpi-shutdown-capture.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Capture Raspberry Pi system state immediately before shutdown
+Documentation=https://github.com/marktheknife/docker-homebridge
+# Run as late as possible during shutdown, before the filesystem goes read-only.
+DefaultDependencies=no
+Before=shutdown.target reboot.target halt.target
+Requires=local-fs.target
+After=local-fs.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStop=/usr/local/bin/rpi-shutdown-capture.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/rpi-shutdown-capture.sh
+++ b/scripts/rpi-shutdown-capture.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Captures a snapshot of system state right before shutdown/reboot.
+# Called by rpi-shutdown-capture.service ExecStop so it runs during the
+# systemd shutdown sequence, before the root filesystem becomes read-only.
+#
+# Output goes to /var/log/rpi-monitor/shutdown-<timestamp>.log
+
+LOG_DIR="/var/log/rpi-monitor"
+OUTFILE="${LOG_DIR}/shutdown-$(date '+%Y-%m-%dT%H:%M:%S').log"
+
+mkdir -p "$LOG_DIR"
+
+vcgencmd_safe() {
+  vcgencmd "$@" 2>/dev/null || echo "unavailable"
+}
+
+decode_throttle() {
+  local raw="$1"
+  local val
+  val=$(( raw ))
+
+  local flags=()
+  (( val & 0x1     )) && flags+=("UNDER_VOLTAGE_NOW")
+  (( val & 0x2     )) && flags+=("ARM_FREQ_CAPPED_NOW")
+  (( val & 0x4     )) && flags+=("THROTTLED_NOW")
+  (( val & 0x8     )) && flags+=("SOFT_TEMP_LIMIT_NOW")
+  (( val & 0x10000 )) && flags+=("under_voltage_occurred")
+  (( val & 0x20000 )) && flags+=("arm_freq_capped_occurred")
+  (( val & 0x40000 )) && flags+=("throttling_occurred")
+  (( val & 0x80000 )) && flags+=("soft_temp_limit_occurred")
+
+  if [[ ${#flags[@]} -eq 0 ]]; then
+    echo "OK"
+  else
+    local IFS="|"
+    echo "${flags[*]}"
+  fi
+}
+
+{
+  echo "════════════════════════════════════════════"
+  echo "  SHUTDOWN CAPTURE  $(date '+%Y-%m-%dT%H:%M:%S')"
+  echo "════════════════════════════════════════════"
+
+  echo ""
+  echo "── System ───────────────────────────────────"
+  echo "  hostname   : $(hostname)"
+  echo "  uptime     : $(uptime)"
+  echo "  who        : $(who | tr '\n' ';')"
+
+  echo ""
+  echo "── Memory ───────────────────────────────────"
+  free -h
+
+  echo ""
+  echo "── CPU frequency ────────────────────────────"
+  for f in /sys/devices/system/cpu/cpu*/cpufreq/scaling_cur_freq; do
+    [[ -r "$f" ]] || continue
+    core="${f#/sys/devices/system/cpu/}"
+    core="${core%%/*}"
+    printf "  %-6s: %d MHz\n" "$core" "$(( $(cat "$f") / 1000 ))"
+  done
+
+  echo ""
+  echo "── Thermal zones ────────────────────────────"
+  for zone_dir in /sys/class/thermal/thermal_zone*; do
+    [[ -r "${zone_dir}/temp" ]] || continue
+    type=$(cat "${zone_dir}/type" 2>/dev/null || basename "$zone_dir")
+    temp_raw=$(cat "${zone_dir}/temp")
+    temp_c=$(awk "BEGIN {printf \"%.1f\", ${temp_raw}/1000}")
+    printf "  %-20s: %s°C\n" "$type" "$temp_c"
+  done
+
+  echo ""
+  echo "── vcgencmd ──────────────────────────────────"
+  echo "  temp       : $(vcgencmd_safe measure_temp)"
+
+  raw_throttle=$(vcgencmd_safe get_throttled)
+  throttle_hex="${raw_throttle#*=}"
+  if [[ "$throttle_hex" == "unavailable" ]]; then
+    throttle_flags="unavailable"
+  else
+    throttle_flags=$(decode_throttle "$throttle_hex")
+  fi
+  echo "  throttled  : ${raw_throttle}  →  ${throttle_flags}"
+
+  for rail in core sdram_c sdram_i sdram_p; do
+    printf "  volts_%-8s: %s\n" "$rail" "$(vcgencmd_safe measure_volts "$rail")"
+  done
+
+  echo ""
+  echo "── Top processes (CPU) ───────────────────────"
+  ps aux --sort=-%cpu | head -11
+
+  echo ""
+  echo "── Disk usage ────────────────────────────────"
+  df -h
+
+  echo ""
+  echo "── Last 50 kernel messages ───────────────────"
+  dmesg --time-format iso 2>/dev/null | tail -50 || dmesg | tail -50
+
+  echo ""
+  echo "── Kernel messages: thermal/power/voltage ────"
+  dmesg --time-format iso 2>/dev/null \
+    | grep -iE "(thermal|throttl|over.temp|under.volt|voltage|power|reboot|panic|oom|killed|segfault)" \
+    || echo "  (none found)"
+
+  echo ""
+  echo "── journald: last 30 errors ──────────────────"
+  journalctl -p err -n 30 --no-pager 2>/dev/null || echo "  (journalctl unavailable)"
+
+  echo ""
+  echo "════════════════════════════════════════════"
+  echo "  END OF SHUTDOWN CAPTURE"
+  echo "════════════════════════════════════════════"
+
+} > "$OUTFILE" 2>&1
+
+# Sync to ensure the file is flushed before the filesystem is remounted r/o.
+sync

--- a/scripts/rpi-wake.sh
+++ b/scripts/rpi-wake.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Sends a Wake-on-LAN magic packet to a Raspberry Pi (or any WoL-enabled host).
+# Run this on any machine on the same network as the Pi.
+#
+# Usage: ./rpi-wake.sh <MAC-address> [broadcast-address]
+#
+# Examples:
+#   ./rpi-wake.sh d8:3a:dd:12:34:56
+#   ./rpi-wake.sh d8:3a:dd:12:34:56 192.168.1.255
+#
+# If you saved the MAC in a file called .rpi-mac next to this script, you can
+# just run:  ./rpi-wake.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MAC_FILE="${SCRIPT_DIR}/.rpi-mac"
+
+# ── Resolve MAC ───────────────────────────────────────────────────────────────
+
+if [[ $# -ge 1 ]]; then
+  MAC="$1"
+elif [[ -f "$MAC_FILE" ]]; then
+  MAC="$(cat "$MAC_FILE" | tr -d '[:space:]')"
+  echo "Using saved MAC: ${MAC}"
+else
+  echo "Usage: $0 <MAC-address> [broadcast-address]" >&2
+  echo "  or save the MAC to ${MAC_FILE}" >&2
+  exit 1
+fi
+
+BROADCAST="${2:-255.255.255.255}"
+
+# Normalise: strip separators, uppercase
+MAC_CLEAN="${MAC//:/}"
+MAC_CLEAN="${MAC_CLEAN//-/}"
+MAC_CLEAN="${MAC_CLEAN^^}"
+
+if [[ ${#MAC_CLEAN} -ne 12 ]]; then
+  echo "Error: '${MAC}' does not look like a valid MAC address." >&2
+  exit 1
+fi
+
+# ── Send magic packet ─────────────────────────────────────────────────────────
+# Try wakeonlan first (common on Linux/macOS), then fall back to Python,
+# then fall back to a raw nc approach.
+
+send_python() {
+  python3 - <<PYEOF
+import socket, sys
+
+mac  = "${MAC_CLEAN}"
+dest = "${BROADCAST}"
+
+payload = bytes.fromhex("FF" * 6 + mac * 16)
+with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
+    s.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+    s.connect((dest, 9))
+    s.send(payload)
+print(f"Magic packet sent to {mac} via {dest}:9")
+PYEOF
+}
+
+if command -v wakeonlan &>/dev/null; then
+  wakeonlan -i "$BROADCAST" "$MAC"
+  echo "Magic packet sent via wakeonlan."
+elif command -v python3 &>/dev/null; then
+  send_python
+else
+  echo "Error: neither 'wakeonlan' nor 'python3' found." >&2
+  echo "Install one: sudo apt install wakeonlan  OR  brew install wakeonlan" >&2
+  exit 1
+fi
+
+echo "Sent WoL magic packet to ${MAC} (broadcast: ${BROADCAST})"
+echo "The Pi should boot within 10–20 seconds if it was in halted state."

--- a/scripts/rpi-wol-setup.sh
+++ b/scripts/rpi-wol-setup.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Configures Wake-on-LAN on a Raspberry Pi 5.
+# Run this ON THE PI (or via the install script).
+#
+# What it does:
+#   1. Enables WoL on eth0 immediately.
+#   2. Installs a systemd service so the WoL setting survives reboots.
+#   3. Prints the MAC address you need for rpi-wake.sh.
+#
+# Usage: sudo bash rpi-wol-setup.sh [interface]  (default: eth0)
+
+set -euo pipefail
+
+IFACE="${1:-eth0}"
+
+info()  { echo "[wol-setup] $*"; }
+fatal() { echo "[ERROR] $*" >&2; exit 1; }
+
+[[ $EUID -eq 0 ]] || fatal "Run as root: sudo bash $0"
+
+# ── Check interface exists ───────────────────────────────────────────────────
+
+if ! ip link show "$IFACE" &>/dev/null; then
+  fatal "Interface '$IFACE' not found. Available: $(ip -o link show | awk -F': ' '{print $2}' | tr '\n' ' ')"
+fi
+
+# ── Install ethtool if needed ────────────────────────────────────────────────
+
+if ! command -v ethtool &>/dev/null; then
+  info "ethtool not found — installing..."
+  apt-get install -y ethtool
+fi
+
+# ── Enable WoL now ───────────────────────────────────────────────────────────
+
+info "Enabling Wake-on-LAN (magic packet) on ${IFACE}..."
+ethtool -s "$IFACE" wol g
+
+current=$(ethtool "$IFACE" | grep -i "wake-on" || true)
+info "ethtool reports: ${current}"
+
+# ── Get MAC address ──────────────────────────────────────────────────────────
+
+MAC=$(cat "/sys/class/net/${IFACE}/address")
+info "MAC address: ${MAC}"
+
+# ── Make WoL persistent via systemd ─────────────────────────────────────────
+# ethtool WoL settings reset on each boot, so we install a lightweight service.
+
+SERVICE=/etc/systemd/system/wol-enable.service
+
+cat > "$SERVICE" <<EOF
+[Unit]
+Description=Enable Wake-on-LAN on ${IFACE}
+After=network.target
+
+[Service]
+Type=oneshot
+ExecStart=/sbin/ethtool -s ${IFACE} wol g
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+systemctl daemon-reload
+systemctl enable --now wol-enable.service
+info "Installed and started wol-enable.service"
+
+# ── EEPROM note ──────────────────────────────────────────────────────────────
+# On Pi 5, WoL works in halted state without EEPROM changes.
+# If the Pi is fully powered off (e.g. after a hard thermal cut), you need
+# the physical J2 button — WoL cannot wake a Pi with no standby power.
+
+echo ""
+echo "══════════════════════════════════════════════════"
+echo "  Wake-on-LAN configured for ${IFACE}"
+echo "  MAC address: ${MAC}"
+echo ""
+echo "  To wake from another machine on the same network:"
+echo "    ./rpi-wake.sh ${MAC}"
+echo ""
+echo "  NOTE: WoL only works if the Pi is in HALTED state"
+echo "  (clean OS shutdown, ethernet still powered)."
+echo "  For a hard power cut, use the J2 physical button."
+echo "══════════════════════════════════════════════════"


### PR DESCRIPTION
Adds a periodic health monitor (30-second interval) and a shutdown-capture
service that fires right before systemd tears down the system, to help diagnose
unexpected reboots/shutdowns on a Raspberry Pi 5.

Logs: temperature (all thermal zones + vcgencmd), throttle bitmask decoded to
human-readable flags (under-voltage, freq-cap, throttling, soft-temp-limit),
per-rail voltages, CPU frequencies, memory, load average, and filtered dmesg.

Shutdown snapshots additionally include top-CPU processes, df, full dmesg tail,
and the last 30 journald errors.

- scripts/rpi-monitor.sh              – polling daemon
- scripts/rpi-monitor.service         – systemd unit for the daemon
- scripts/rpi-shutdown-capture.sh     – one-shot snapshot script
- scripts/rpi-shutdown-capture.service – systemd unit (ExecStop fires on shutdown)
- scripts/rpi-monitor-install.sh      – scp + remote-install helper

https://claude.ai/code/session_016mA2EePy7gajL7VwarBTG2